### PR TITLE
Add AI Assistant UI setup

### DIFF
--- a/AI_Assistant/README.md
+++ b/AI_Assistant/README.md
@@ -1,0 +1,17 @@
+# AI Assistant for Unreal Engine
+
+This folder contains Python utilities for the in-editor AI Assistant.
+
+## Phase 1: Chat UI Setup
+
+1. **Create an Editor Utility Widget** named `WBP_AI_Assistant` inside your project.
+2. Design the layout with the following elements:
+   - `ChatHistoryScrollBox` (ScrollBox)
+   - `ChatHistoryVerticalBox` (VerticalBox inside the scroll box)
+   - `UserInputTextBox` (MultiLineEditableTextBox)
+   - `SendButton` (Button)
+3. Create a second widget `WBP_ChatMessage` containing a `TextBlock` and an exposed parameter for the sender.
+4. Bind the `SendButton` click event to read the text, create a `WBP_ChatMessage`, add it to the vertical box, clear the input field and call a Python function named `process_user_command(text)`.
+5. Add a toolbar button or menu entry that opens `WBP_AI_Assistant` so it can be launched from the editor.
+
+The Python modules in this directory provide the backend logic to process user commands and can be called from the widget's graph.

--- a/AI_Assistant/nlp_service.py
+++ b/AI_Assistant/nlp_service.py
@@ -1,0 +1,45 @@
+"""Simple keyword based NLP service."""
+import re
+from typing import Dict, Any
+
+
+class NLPService:
+    def __init__(self) -> None:
+        self.intent_keywords = {
+            "create": ["create", "make", "add", "spawn"],
+            "delete": ["delete", "remove", "destroy"],
+            "move": ["move", "translate", "position"],
+            "rotate": ["rotate", "turn", "orient"],
+            "scale": ["scale", "resize"],
+            "select": ["select", "find", "get"],
+            "set_material": ["material", "texture", "apply material"],
+            "get_info": ["info", "details", "properties", "what is"],
+        }
+
+    def parse_command(self, text: str) -> Dict[str, Any]:
+        text_lower = text.lower()
+        intent = None
+        for key, kws in self.intent_keywords.items():
+            if any(kw in text_lower for kw in kws):
+                intent = key
+                break
+
+        entities: Dict[str, Any] = {}
+
+        # crude regex for position extraction: x 100 y 50 z 0
+        position_match = re.search(r"x\s*(-?\d+)\s*y\s*(-?\d+)\s*z\s*(-?\d+)", text_lower)
+        if position_match:
+            entities["position"] = {
+                "x": int(position_match.group(1)),
+                "y": int(position_match.group(2)),
+                "z": int(position_match.group(3)),
+            }
+
+        # extract simple object type (first word after intent)
+        if intent:
+            pattern = rf"{intent}\s+(\w+)"
+            obj_match = re.search(pattern, text_lower)
+            if obj_match:
+                entities["object_type"] = obj_match.group(1)
+
+        return {"intent": intent, "entities": entities}

--- a/AI_Assistant/ui_setup.py
+++ b/AI_Assistant/ui_setup.py
@@ -1,0 +1,27 @@
+"""Utility to spawn the AI Assistant widget inside the editor."""
+import unreal
+
+ASSET_PATH = "/Game/AI_Assistant/WBP_AI_Assistant"
+
+
+def open_ai_assistant():
+    """Open the AI assistant widget if it exists."""
+    subsystem = unreal.get_editor_subsystem(unreal.EditorUtilitySubsystem)
+    if unreal.EditorAssetLibrary.does_asset_exist(ASSET_PATH):
+        subsystem.spawn_and_register_tab(ASSET_PATH)
+    else:
+        unreal.log_warning(f"AI Assistant widget not found: {ASSET_PATH}")
+
+
+def process_user_command(text: str):
+    """Entry point called from the UI Blueprint."""
+    from .nlp_service import NLPService
+    from .command_dispatcher import CommandDispatcher
+
+    service = NLPService()
+    dispatcher = CommandDispatcher()
+
+    command = service.parse_command(text)
+    result = dispatcher.dispatch_command(command)
+
+    return result


### PR DESCRIPTION
## Summary
- add AI Assistant package with initial UI setup utilities
- describe how to create the Editor Utility Widget for the chat UI

## Testing
- `python MCP/TestScripts/run_all_tests.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68814d4916c08329be4c907ea9b04dee