### PR TITLE
Implement CommandDispatcher and Unreal action functions

### DIFF
--- a/AI_Assistant/command_dispatcher.py
+++ b/AI_Assistant/command_dispatcher.py
@@ -1,0 +1,33 @@
+from typing import Any, Callable, Dict
+
+from . import unreal_actions
+
+
+class CommandDispatcher:
+    """Map parsed intents to Unreal action functions."""
+
+    def __init__(self) -> None:
+        self.intent_map: Dict[str, Callable[[Dict[str, Any]], str]] = {
+            "create": unreal_actions.create_object,
+            "move": unreal_actions.move_object,
+            "delete": unreal_actions.delete_object,
+            "rotate": unreal_actions.rotate_object,
+            "scale": unreal_actions.scale_object,
+        }
+
+    def dispatch_command(self, command: Dict[str, Any]) -> str:
+        """Execute an action based on the parsed command."""
+        intent = command.get("intent")
+        entities = command.get("entities", {})
+
+        if intent is None:
+            return "No intent detected."
+
+        action = self.intent_map.get(intent)
+        if not action:
+            return f"Unknown intent: {intent}"
+
+        try:
+            return action(entities)
+        except Exception as exc:  # pragma: no cover - relies on Unreal API
+            return f"Error executing {intent}: {exc}"

--- a/AI_Assistant/unreal_actions.py
+++ b/AI_Assistant/unreal_actions.py
@@ -1,0 +1,72 @@
+"""Unreal Engine action implementations for the AI Assistant."""
+
+from typing import Any, Dict
+
+import unreal
+
+
+def _get_selected_actors() -> list[unreal.Actor]:
+    """Return all currently selected actors in the editor."""
+    return list(unreal.EditorLevelLibrary.get_selected_level_actors())
+
+
+def create_object(entities: Dict[str, Any]) -> str:
+    """Spawn a basic actor like a cube or sphere."""
+    object_type = entities.get("object_type")
+    position = entities.get("position", {"x": 0, "y": 0, "z": 0})
+
+    mesh_path = None
+    if object_type in {"cube", "box"}:
+        mesh_path = "/Engine/BasicShapes/Cube.Cube"
+    elif object_type == "sphere":
+        mesh_path = "/Engine/BasicShapes/Sphere.Sphere"
+
+    if mesh_path is None:
+        return f"Unsupported object type: {object_type}"
+
+    location = unreal.Vector(position.get("x", 0), position.get("y", 0), position.get("z", 0))
+    rotation = unreal.Rotator(0.0, 0.0, 0.0)
+    mesh = unreal.EditorAssetLibrary.load_asset(mesh_path)
+    actor = unreal.EditorLevelLibrary.spawn_actor_from_object(mesh, location, rotation)
+    return f"Created {actor.get_name()}"
+
+
+def move_object(entities: Dict[str, Any]) -> str:
+    """Move selected actors to a new location."""
+    position = entities.get("position")
+    if not position:
+        return "No position specified"
+
+    location = unreal.Vector(position.get("x", 0), position.get("y", 0), position.get("z", 0))
+    actors = _get_selected_actors()
+    for actor in actors:
+        actor.set_actor_location(location, False, True)
+    return f"Moved {len(actors)} actor(s)"
+
+
+def delete_object(entities: Dict[str, Any]) -> str:
+    """Delete selected actors from the level."""
+    actors = _get_selected_actors()
+    for actor in actors:
+        unreal.EditorLevelLibrary.destroy_actor(actor)
+    return f"Deleted {len(actors)} actor(s)"
+
+
+def rotate_object(entities: Dict[str, Any]) -> str:
+    """Rotate selected actors."""
+    rotation = entities.get("rotation", {})
+    rotator = unreal.Rotator(rotation.get("pitch", 0.0), rotation.get("yaw", 0.0), rotation.get("roll", 0.0))
+    actors = _get_selected_actors()
+    for actor in actors:
+        actor.set_actor_rotation(rotator, False)
+    return f"Rotated {len(actors)} actor(s)"
+
+
+def scale_object(entities: Dict[str, Any]) -> str:
+    """Scale selected actors."""
+    scale = entities.get("scale", {})
+    scale_vector = unreal.Vector(scale.get("x", 1.0), scale.get("y", 1.0), scale.get("z", 1.0))
+    actors = _get_selected_actors()
+    for actor in actors:
+        actor.set_actor_scale3d(scale_vector)
+    return f"Scaled {len(actors)} actor(s)"


### PR DESCRIPTION
## Summary
- add `CommandDispatcher` for mapping intents to actions
- implement Unreal action helpers for create/move/delete/rotate/scale
- wire dispatcher into `process_user_command`

## Testing
- `python3 -m py_compile AI_Assistant/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68814ea81e6883298e3a71131300e036