### PR TITLE
Update MCP version and add configurable port

### DIFF
--- a/MCP/TestScripts/test_commands_blueprint.py
+++ b/MCP/TestScripts/test_commands_blueprint.py
@@ -66,42 +66,12 @@ def test_create_blueprint():
         # Store the actual path from the response for later tests
         if response["status"] == "success":
             blueprint_path = response["result"]["path"]
+            file_path = response["result"].get("file_path")
             print(f"Blueprint created at: {blueprint_path}")
-            
-            # Check if the blueprint file exists in either expected location
-            if os.path.exists(expected_path_in_dir):
-                print(f"✓ Blueprint file found at: {expected_path_in_dir}")
-            elif os.path.exists(expected_path_as_asset):
-                print(f"✓ Blueprint file found at: {expected_path_as_asset}")
+            if file_path and os.path.exists(file_path):
+                print(f"\u2713 Blueprint file found at: {file_path}")
             else:
-                print(f"✗ Blueprint file NOT found at expected locations")
-                
-                # Try to find the file in other possible locations
-                possible_locations = [
-                    os.path.join(project_dir, "Saved", "Blueprints"),
-                    os.path.join(project_dir, "Saved", "Autosaves", "Game", "Blueprints"),
-                    os.path.join(project_dir, "Plugins", "UnrealArchitect", "Content", "Blueprints")
-                ]
-                
-                for location in possible_locations:
-                    potential_path = os.path.join(location, f"{blueprint_name}.uasset")
-                    if os.path.exists(potential_path):
-                        print(f"✓ Blueprint file found at alternative location: {potential_path}")
-                        break
-                else:
-                    print("✗ Blueprint file not found in any expected location")
-                    
-                    # Try to find the file using a more extensive search
-                    print("Searching for the blueprint file in the project directory...")
-                    for root, dirs, files in os.walk(project_dir):
-                        for file in files:
-                            if "Blueprint" in file and file.endswith(".uasset"):
-                                found_path = os.path.join(root, file)
-                                print(f"✓ Blueprint file found at: {found_path}")
-                                break
-                        else:
-                            continue
-                        break
+                print("\u2717 Blueprint file not found at reported path")
             
         return response["status"] == "success"
     except Exception as e:

--- a/MCP/get_port.py
+++ b/MCP/get_port.py
@@ -1,0 +1,14 @@
+import os
+import re
+from pathlib import Path
+
+plugin_dir = Path(__file__).resolve().parent.parent
+const_path = plugin_dir / "Source" / "UnrealArchitect" / "Public" / "MCPConstants.h"
+port = 13377
+if const_path.exists():
+    text = const_path.read_text()
+    m = re.search(r"DEFAULT_PORT\s*=\s*(\d+)", text)
+    if m:
+        port = int(m.group(1))
+print(port)
+

--- a/MCP/requirements.txt
+++ b/MCP/requirements.txt
@@ -1,2 +1,2 @@
-mcp>=0.1.0
-# socket and json are part of Python's standard library and don't need to be listed 
+mcp>=1.4.0
+# socket and json are part of Python's standard library and don't need to be listed

--- a/MCP/run_unreal_architect.bat
+++ b/MCP/run_unreal_architect.bat
@@ -21,7 +21,11 @@ call "%ENV_DIR%\Scripts\activate.bat" >nul 2>&1
 REM Log start message to stderr
 echo Starting Unreal Architect bridge... >&2
 
-REM Run the Python bridge script, keeping stdout clean for MCP
-python "%SCRIPT_DIR%\unreal_mcp_bridge.py" %*
+REM Determine port from MCPConstants
+for /f "usebackq delims=" %%p in (`"%PYTHON_PATH%" "%SCRIPT_DIR%\get_port.py"`) do set MCP_PORT=%%p
+
+REM Run the Python bridge script with port argument
+set MCP_PORT
+python "%SCRIPT_DIR%\unreal_mcp_bridge.py" --port %MCP_PORT% %*
 
 :end

--- a/MCP/run_unreal_architect.sh
+++ b/MCP/run_unreal_architect.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/python_env/bin/activate"
+PORT=$(python "$SCRIPT_DIR/get_port.py")
+export MCP_PORT="$PORT"
+python "$SCRIPT_DIR/unreal_mcp_bridge.py" --port "$PORT" "$@"
+

--- a/MCP/setup_unreal_architect.sh
+++ b/MCP/setup_unreal_architect.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_DIR="$SCRIPT_DIR/python_env"
+MODULES_DIR="$SCRIPT_DIR/python_modules"
+
+if [ ! -d "$ENV_DIR" ]; then
+    python3 -m venv "$ENV_DIR"
+fi
+source "$ENV_DIR/bin/activate"
+
+pip install --upgrade pip
+pip install -r "$SCRIPT_DIR/requirements.txt"
+
+cat > "$SCRIPT_DIR/run_unreal_architect.sh" <<'RUNEOF'
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/python_env/bin/activate"
+PORT=$(python "$SCRIPT_DIR/get_port.py")
+export MCP_PORT="$PORT"
+python "$SCRIPT_DIR/unreal_mcp_bridge.py" --port "$PORT" "$@"
+RUNEOF
+chmod +x "$SCRIPT_DIR/run_unreal_architect.sh"
+
+echo "Setup complete. Use run_unreal_architect.sh to start the bridge."
+

--- a/MCP/utils/__init__.py
+++ b/MCP/utils/__init__.py
@@ -34,12 +34,20 @@ except Exception as e:
     # If anything goes wrong, use the defaults (which are already defined)
     print(f"Warning: Could not read constants from MCPConstants.h: {e}", file=sys.stderr)
 
-def send_command(command_type, params=None):
+# Allow environment variable override
+env_port = os.environ.get("MCP_PORT")
+if env_port:
+    try:
+        DEFAULT_PORT = int(env_port)
+    except ValueError:
+        print(f"Invalid MCP_PORT environment variable: {env_port}", file=sys.stderr)
+
+def send_command(command_type, params=None, port=DEFAULT_PORT):
     """Send a command to the C++ MCP server and return the response."""
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.settimeout(DEFAULT_TIMEOUT)  # Set a timeout
-            s.connect(("localhost", DEFAULT_PORT))  # Connect to Unreal C++ server
+            s.connect(("localhost", port))  # Connect to Unreal C++ server
             command = {
                 "type": command_type,
                 "params": params or {}

--- a/MCP/utils/command_utils.py
+++ b/MCP/utils/command_utils.py
@@ -33,12 +33,20 @@ try:
 except Exception as e:
     print(f"Warning: Could not read constants from MCPConstants.h: {e}", file=sys.stderr)
 
-def send_command(command_type, params=None):
+# Allow environment variable override
+env_port = os.environ.get("MCP_PORT")
+if env_port:
+    try:
+        DEFAULT_PORT = int(env_port)
+    except ValueError:
+        print(f"Invalid MCP_PORT environment variable: {env_port}", file=sys.stderr)
+
+def send_command(command_type, params=None, port=DEFAULT_PORT):
     """Send a command to the C++ MCP server and return the response."""
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.settimeout(DEFAULT_TIMEOUT)
-            s.connect(("localhost", DEFAULT_PORT))
+            s.connect(("localhost", port))
             command = {
                 "type": command_type,
                 "params": params or {}

--- a/Source/UnrealArchitect/Private/MCPCommandHandlers.cpp
+++ b/Source/UnrealArchitect/Private/MCPCommandHandlers.cpp
@@ -13,6 +13,7 @@
 #include "Kismet/KismetSystemLibrary.h"
 #include "Engine/Blueprint.h"
 #include "Engine/BlueprintGeneratedClass.h"
+#include "Misc/MessageDialog.h"
 
 
 //
@@ -411,6 +412,17 @@ TSharedPtr<FJsonObject> FMCPDeleteObjectHandler::Execute(const TSharedPtr<FJsonO
 //
 TSharedPtr<FJsonObject> FMCPExecutePythonHandler::Execute(const TSharedPtr<FJsonObject> &Params, FSocket *ClientSocket)
 {
+    static bool bConsentGiven = false;
+    if (!bConsentGiven)
+    {
+        EAppReturnType::Type Response = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(TEXT("Execute arbitrary Python code?")));
+        if (Response == EAppReturnType::No)
+        {
+            return CreateErrorResponse(TEXT("User declined to execute Python code"));
+        }
+        bConsentGiven = true;
+    }
+
     // Check if we have code or file parameter
     FString PythonCode;
     FString PythonFile;


### PR DESCRIPTION
## Summary
- update to mcp>=1.4.0
- read the MCP port from `MCPConstants.h` at runtime
- pass the port as an argument from the run scripts
- add shell setup/run scripts for macOS/Linux
- prompt for consent before executing Python code
- return blueprint asset file path when creating blueprints

## Testing
- `python3 MCP/TestScripts/run_all_tests.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6881600fd3008329bdd82573bb4d6d1f